### PR TITLE
Fix typo in SystemdServiceManager

### DIFF
--- a/tilework.core/Services/SystemdServiceManager.cs
+++ b/tilework.core/Services/SystemdServiceManager.cs
@@ -61,7 +61,7 @@ public class SystemdServiceManager : IServiceManager
                 actionCommand = "reload";
                 break;
             default:
-                throw new ArgumentException("Unkown service manager action received");
+                throw new ArgumentException("Unknown service manager action received");
         }
 
         ExecuteCommand("systemctl", $"{actionCommand} {serviceName}");


### PR DESCRIPTION
## Summary
- correct a typo in `SystemdServiceManager`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540c6bbe288325858b7a4c2c4ed5e9