### PR TITLE
Fix LoadBalancerDetail null reference

### DIFF
--- a/tilework.ui/Components/Pages/LoadBalancing/LoadBalancerDetail.razor
+++ b/tilework.ui/Components/Pages/LoadBalancing/LoadBalancerDetail.razor
@@ -81,14 +81,14 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var _item = await _loadBalancerService.GetLoadBalancer(Id);
+        _item = await _loadBalancerService.GetLoadBalancer(Id);
         if(_item == null)
         {
             _navigationManager.NavigateTo("/lb/loadbalancers");
             _snackbar.Add($"Load balancer {Id} not found", Severity.Error);
+            return;
         }
-            
-        
+
         _breadcrumbs.Add(new BreadcrumbItem(_item.Name, href: null, disabled: true));
 
         _actions = new List<ActionItem>


### PR DESCRIPTION
## Summary
- fix LoadBalancerDetail by assigning loaded object to field and returning when not found

## Testing
- `dotnet test`
- `dotnet build` *(fails: CertificateList.razor CS1061)*

------
https://chatgpt.com/codex/tasks/task_e_6897509446088325830f98fde816009b