### PR TITLE
Load existing TargetGroup data in edit form

### DIFF
--- a/tilework.ui/Components/Pages/LoadBalancing/TargetGroupEdit.razor
+++ b/tilework.ui/Components/Pages/LoadBalancing/TargetGroupEdit.razor
@@ -33,14 +33,16 @@
     {
         try {
             Object = await LoadBalancerService.GetTargetGroup(Id);
-            if(Object == null)
+            if (Object == null)
                 throw new KeyNotFoundException();
+
+            form = _mapper.Map<EditTargetGroupForm>(Object);
         }
         catch (KeyNotFoundException) {
             NavigationManager.NavigateTo("/lb/targetgroups");
             Snackbar.Add($"Target group {Id} not found", Severity.Error);
         }
-        
+
         _breadcrumbs.Add(new BreadcrumbItem(Object.Name, href: $"/lb/targetgroups/{Id}"));
         _breadcrumbs.Add(new BreadcrumbItem("edit", href: null, disabled: true));
     }

--- a/tilework.ui/Mappers/FormMappingProfile.cs
+++ b/tilework.ui/Mappers/FormMappingProfile.cs
@@ -12,6 +12,7 @@ public class FormMappingProfile : Profile
     {
         CreateMap<NewTargetGroupForm, TargetGroup>();
         CreateMap<EditTargetGroupForm, TargetGroup>();
+        CreateMap<TargetGroup, EditTargetGroupForm>();
 
         CreateMap<NewCertificateAuthorityForm, CertificateAuthority>();
 


### PR DESCRIPTION
## Summary
- Map `TargetGroup` to `EditTargetGroupForm` via AutoMapper
- Populate edit form with existing target group details when editing

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6899b9403360832586a167c160838391