### PR TITLE
Fix port validator nullability and range check

### DIFF
--- a/tilework.ui/Components/Validators/ValidatePort.cs
+++ b/tilework.ui/Components/Validators/ValidatePort.cs
@@ -1,8 +1,8 @@
 public static partial class Validators
 {
-    public static string ValidatePort(int? value)
+    public static string? ValidatePort(int? value)
     {
-        if(value == null || value > 65535 || value < 0)
+        if (value == null || value > 65535 || value < 1)
             return "Value must be between 1 and 65535";
         return null;
     }


### PR DESCRIPTION
## Summary
- make ValidatePort return nullable string and enforce 1-65535 range

## Testing
- `dotnet build tilework.sln`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899cf0aadc8832594e4cba6808f1b91