### PR TITLE
Align and outline ConditionForm delete button

### DIFF
--- a/tilework.ui/Components/Forms/ConditionForm.razor
+++ b/tilework.ui/Components/Forms/ConditionForm.razor
@@ -16,10 +16,14 @@
             @for (var i = 0; i < Condition.Values.Count; i++)
             {
                 var index = i;
-                <MudStack Direction="Row" AlignItems="AlignItems.Center" Spacing="1">
-                    <MudTextField @bind-Value="Condition.Values[index]" Label="Value" Variant="Variant.Outlined" Required="true" />
-                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="@(() => RemoveValue(index))" />
-                </MudStack>
+                <MudGrid>
+                    <MudItem xs="11">
+                        <MudTextField @bind-Value="Condition.Values[index]" Label="Value" Variant="Variant.Outlined" Required="true" />
+                    </MudItem>
+                    <MudItem xs="1" Class="d-flex align-center">
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Variant="Variant.Outlined" OnClick="@(() => RemoveValue(index))" />
+                    </MudItem>
+                </MudGrid>
             }
             <MudIconButton Icon="@Icons.Material.Filled.Add" Color="Color.Primary" OnClick="AddValue" />
         </MudStack>


### PR DESCRIPTION
## Summary
- Keep condition value delete button beside its text field using MudGrid instead of inline flex styles
- Use an outlined style for the delete button

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689ae90dbdac83258fed0265d2f31493