### PR TITLE
Ensure new conditions start with a value

### DIFF
--- a/tilework.ui/Components/Forms/ConditionForm.razor
+++ b/tilework.ui/Components/Forms/ConditionForm.razor
@@ -33,6 +33,15 @@
 @code {
     [Parameter] public Condition Condition { get; set; }
 
+    protected override void OnParametersSet()
+    {
+        if (Condition?.Values == null || Condition.Values.Count == 0)
+        {
+            Condition.Values ??= new List<string>();
+            Condition.Values.Add(string.Empty);
+        }
+    }
+
     void AddValue()
     {
         Condition.Values.Add(string.Empty);
@@ -43,6 +52,10 @@
         if (index >= 0 && index < Condition.Values.Count)
         {
             Condition.Values.RemoveAt(index);
+            if (Condition.Values.Count == 0)
+            {
+                Condition.Values.Add(string.Empty);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- initialize condition form with a default value when none are provided
- prevent all values from being removed

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689af2f037e483258746bbfb2d7df1da