### PR TITLE
Add load balancer certificate management

### DIFF
--- a/tilework.core/Interfaces/ILoadBalancerService.cs
+++ b/tilework.core/Interfaces/ILoadBalancerService.cs
@@ -1,4 +1,5 @@
 using Tilework.Core.LoadBalancing.Models;
+using Tilework.Core.CertificateManagement.Models;
 
 namespace Tilework.Core.Interfaces;
 
@@ -13,6 +14,11 @@ public interface ILoadBalancerService
     public Task<List<RuleDTO>> GetRules(ApplicationLoadBalancerDTO balancer);
     public Task AddRule(ApplicationLoadBalancerDTO balancer, RuleDTO rule);
     public Task RemoveRule(ApplicationLoadBalancerDTO balancer, RuleDTO rule);
+
+
+    public Task<List<CertificateDTO>> GetCertificates(BaseLoadBalancerDTO balancer);
+    public Task AddCertificate(BaseLoadBalancerDTO balancer, Guid certificateId);
+    public Task RemoveCertificate(BaseLoadBalancerDTO balancer, Guid certificateId);
 
 
     public Task<List<TargetGroupDTO>> GetTargetGroups();

--- a/tilework.ui/Components/Dialogs/CertificateDialog.razor
+++ b/tilework.ui/Components/Dialogs/CertificateDialog.razor
@@ -1,0 +1,46 @@
+@using Tilework.Core.CertificateManagement.Models
+
+@namespace Tilework.Ui.Components.Dialogs
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.Add" Class="mr-3 mb-n1" />
+            Add certificate
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="form">
+            <MudSelect T="Guid" @bind-Value="SelectedCertificate" Label="Certificate" Variant="Variant.Outlined" AnchorOrigin="Origin.BottomCenter" Required="true">
+                @foreach (var cert in Certificates)
+                {
+                    <MudSelectItem T="Guid" Value="@cert.Id">@cert.Name (@cert.Fqdn)</MudSelectItem>
+                }
+            </MudSelect>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit">Add</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; }
+
+    [Parameter] public List<CertificateDTO> Certificates { get; set; } = new();
+
+    private MudForm form;
+    public Guid SelectedCertificate { get; set; }
+
+    async Task Submit()
+    {
+        await form.Validate();
+        if (form.IsValid)
+        {
+            MudDialog.Close(DialogResult.Ok(SelectedCertificate));
+        }
+    }
+
+    void Cancel() => MudDialog.Cancel();
+}

--- a/tilework.ui/Components/Pages/LoadBalancing/LoadBalancerDetail.razor
+++ b/tilework.ui/Components/Pages/LoadBalancing/LoadBalancerDetail.razor
@@ -2,6 +2,8 @@
 @using Tilework.Core.LoadBalancing.Enums
 @using Tilework.Core.Enums
 @using Tilework.Core.Interfaces
+@using Tilework.Core.CertificateManagement.Models
+@using System.Linq
 
 @namespace Tilework.Ui.Components.Pages
 
@@ -9,6 +11,7 @@
 @inject IDialogService _dialogService
 @inject NavigationManager _navigationManager
 @inject ISnackbar _snackbar
+@inject ICertificateManagementService _certificateService
 
 @page "/lb/loadbalancers/{Id:guid}"
 
@@ -82,7 +85,22 @@
             </MudTabPanel>
         }
         <MudTabPanel Text="Certificates">
-            <MudText>TODO</MudText>
+            <MudDataGrid T="CertificateDTO" Outlined="true" Items="_certificates" Hover="true">
+                <ToolBarContent>
+                    <MudText Typo="Typo.h6">Certificates</MudText>
+                    <MudSpacer />
+                    <MudButton Variant="Variant.Filled" DropShadow="false" Color="Color.Primary" OnClick="AddCertificate">Add certificate</MudButton>
+                </ToolBarContent>
+                <Columns>
+                    <PropertyColumn Property="t => t.Name" Title="Name" Editable="false" />
+                    <PropertyColumn Property="t => t.Fqdn" Title="FQDN" Editable="false" />
+                    <TemplateColumn CellClass="d-flex justify-end">
+                        <CellTemplate>
+                            <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Delete" Color="Color.Error" OnClick="@(() => ConfirmDeleteCertificate(context.Item))" />
+                        </CellTemplate>
+                    </TemplateColumn>
+                </Columns>
+            </MudDataGrid>
         </MudTabPanel>
         <MudTabPanel Text="Monitoring">
             <MudText>TODO</MudText>
@@ -99,6 +117,7 @@
 
     private BaseLoadBalancerDTO _item;
     private List<RuleDTO> _rules = new();
+    private List<CertificateDTO> _certificates = new();
 
     private List<BreadcrumbItem> _breadcrumbs = new List<BreadcrumbItem>
     {
@@ -122,6 +141,8 @@
         {
             _rules = await _loadBalancerService.GetRules(appBalancer);
         }
+
+        _certificates = await _loadBalancerService.GetCertificates(_item);
 
         _breadcrumbs.Add(new BreadcrumbItem(_item.Name, href: null, disabled: true));
 
@@ -188,6 +209,49 @@
             await _loadBalancerService.RemoveRule(appBalancer, rule);
             await _loadBalancerService.ApplyConfiguration();
         }
+    }
+
+    private async Task AddCertificate()
+    {
+        var parameters = new DialogParameters<CertificateDialog>();
+        parameters.Add(x => x.Certificates, await GetAvailableCertificates());
+
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+
+        var dialog = _dialogService.Show<CertificateDialog>("Add certificate", parameters, options);
+        var result = await dialog.Result;
+        if (!result.Canceled)
+        {
+            var certId = (Guid)result.Data;
+            await _loadBalancerService.AddCertificate(_item, certId);
+            _certificates = await _loadBalancerService.GetCertificates(_item);
+            await _loadBalancerService.ApplyConfiguration();
+        }
+    }
+
+    private async Task ConfirmDeleteCertificate(CertificateDTO certificate)
+    {
+        var parameters = new DialogParameters<ConfirmDialog>();
+        parameters.Add(x => x.ContentText, "Do you really want to delete the certificate from the load balancer? This process cannot be undone.");
+        parameters.Add(x => x.ButtonText, "Delete");
+        parameters.Add(x => x.Color, Color.Error);
+
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+
+        var dialog = _dialogService.Show<ConfirmDialog>("Delete", parameters, options);
+        var result = await dialog.Result;
+        if (!result.Canceled)
+        {
+            await _loadBalancerService.RemoveCertificate(_item, certificate.Id);
+            _certificates = await _loadBalancerService.GetCertificates(_item);
+            await _loadBalancerService.ApplyConfiguration();
+        }
+    }
+
+    private async Task<List<CertificateDTO>> GetAvailableCertificates()
+    {
+        var all = await _certificateService.GetCertificates();
+        return all.Where(c => !_item.Certificates.Contains(c.Id)).ToList();
     }
 
     private async Task<List<TargetGroupDTO>> GetAlbTargetGroups()


### PR DESCRIPTION
## Summary
- show certificates for load balancers and allow add/remove
- implement certificate selection dialog
- extend service and interface for certificate operations

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a0546a79a48325994f0e100e3f239a