### PR TITLE
Enable editing targets in target group detail

### DIFF
--- a/loadbalancing.tile/Services/LoadBalancerService.cs
+++ b/loadbalancing.tile/Services/LoadBalancerService.cs
@@ -253,6 +253,18 @@ public class LoadBalancerService : ILoadBalancerService
         await _dbContext.SaveChangesAsync();
     }
 
+    public async Task UpdateTarget(TargetGroupDTO group, TargetDTO target)
+    {
+        var entity = await _dbContext.TargetGroups.FindAsync(group.Id);
+        var t = entity.Targets.FirstOrDefault(t => t.Id == target.Id);
+        if (t != null)
+        {
+            _mapper.Map(target, t);
+            _dbContext.TargetGroups.Update(entity);
+            await _dbContext.SaveChangesAsync();
+        }
+    }
+
     public async Task RemoveTarget(TargetGroupDTO group, TargetDTO target)
     {
         var entity = await _dbContext.TargetGroups.FindAsync(group.Id);

--- a/tilework.core/Interfaces/ILoadBalancerService.cs
+++ b/tilework.core/Interfaces/ILoadBalancerService.cs
@@ -33,6 +33,7 @@ public interface ILoadBalancerService
 
     public Task<List<TargetDTO>> GetTargets(TargetGroupDTO group);
     public Task AddTarget(TargetGroupDTO group, TargetDTO target);
+    public Task UpdateTarget(TargetGroupDTO group, TargetDTO target);
     public Task RemoveTarget(TargetGroupDTO group, TargetDTO target);
 
     public Task ApplyConfiguration();

--- a/tilework.ui/Components/Dialogs/TargetDialog.razor
+++ b/tilework.ui/Components/Dialogs/TargetDialog.razor
@@ -6,8 +6,8 @@
 <MudDialog>
     <TitleContent>
         <MudText Typo="Typo.h6">
-            <MudIcon Icon="@Icons.Material.Filled.Add" Class="mr-3 mb-n1"/>
-            Add target
+            <MudIcon Icon="@Icon" Class="mr-3 mb-n1"/>
+            @Title
         </MudText>
     </TitleContent>
     <DialogContent>
@@ -19,7 +19,7 @@
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
-        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit">Add</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit">@ButtonText</MudButton>
     </DialogActions>
 </MudDialog>
 
@@ -27,6 +27,9 @@
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; }
 
     [Parameter] public TargetDTO Target { get; set; } = new();
+    [Parameter] public string Title { get; set; } = "Add target";
+    [Parameter] public string ButtonText { get; set; } = "Add";
+    [Parameter] public string Icon { get; set; } = Icons.Material.Filled.Add;
 
     private MudForm form;
 

--- a/tilework.ui/Components/Pages/LoadBalancing/TargetGroupDetail.razor
+++ b/tilework.ui/Components/Pages/LoadBalancing/TargetGroupDetail.razor
@@ -27,7 +27,7 @@
                     <PropertyColumn Property="t => t.Port" Title="Port" />
                     <TemplateColumn CellClass="d-flex justify-end">
                         <CellTemplate>
-                            <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@context.Actions.StartEditingItemAsync" />
+                            <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@(() => EditTarget(context.Item))" />
                             <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Delete" Color="Color.Error" OnClick="@(() => ConfirmDeleteTarget(context.Item))" />
                         </CellTemplate>
                     </TemplateColumn>
@@ -105,6 +105,33 @@
         if (!result.Canceled)
         {
             await _loadBalancerService.AddTarget(_item, target);
+            await GetTargets();
+            await _loadBalancerService.ApplyConfiguration();
+        }
+    }
+
+    private async Task EditTarget(TargetDTO target)
+    {
+        var targetEdit = new TargetDTO
+        {
+            Id = target.Id,
+            Host = target.Host,
+            Port = target.Port
+        };
+
+        var parameters = new DialogParameters<TargetDialog>();
+        parameters.Add(x => x.Target, targetEdit);
+        parameters.Add(x => x.Title, "Edit target");
+        parameters.Add(x => x.ButtonText, "Save");
+        parameters.Add(x => x.Icon, Icons.Material.Filled.Edit);
+
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+
+        var dialog = _dialogService.Show<TargetDialog>("Edit target", parameters, options);
+        var result = await dialog.Result;
+        if (!result.Canceled)
+        {
+            await _loadBalancerService.UpdateTarget(_item, targetEdit);
             await GetTargets();
             await _loadBalancerService.ApplyConfiguration();
         }


### PR DESCRIPTION
## Summary
- allow editing existing targets from the target group detail page
- make target dialog reusable with custom title and button text
- add backend support for updating targets

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a881839c83259ec90ce3a3b1fb95