### PR TITLE
Enable editing of load balancer rules

### DIFF
--- a/loadbalancing.tile/Services/LoadBalancerService.cs
+++ b/loadbalancing.tile/Services/LoadBalancerService.cs
@@ -134,6 +134,18 @@ public class LoadBalancerService : ILoadBalancerService
         await _dbContext.SaveChangesAsync();
     }
 
+    public async Task UpdateRule(ApplicationLoadBalancerDTO balancer, RuleDTO rule)
+    {
+        var entity = (ApplicationLoadBalancer?) await _dbContext.LoadBalancers.FindAsync(balancer.Id);
+        var r = entity.Rules.FirstOrDefault(t => t.Id == rule.Id);
+        if (r != null)
+        {
+            _mapper.Map(rule, r);
+            _dbContext.LoadBalancers.Update(entity);
+            await _dbContext.SaveChangesAsync();
+        }
+    }
+
     public async Task RemoveRule(ApplicationLoadBalancerDTO balancer, RuleDTO rule)
     {
         var entity = (ApplicationLoadBalancer?) await _dbContext.LoadBalancers.FindAsync(balancer.Id);

--- a/tilework.core/Interfaces/ILoadBalancerService.cs
+++ b/tilework.core/Interfaces/ILoadBalancerService.cs
@@ -13,6 +13,7 @@ public interface ILoadBalancerService
 
     public Task<List<RuleDTO>> GetRules(ApplicationLoadBalancerDTO balancer);
     public Task AddRule(ApplicationLoadBalancerDTO balancer, RuleDTO rule);
+    public Task UpdateRule(ApplicationLoadBalancerDTO balancer, RuleDTO rule);
     public Task RemoveRule(ApplicationLoadBalancerDTO balancer, RuleDTO rule);
 
 

--- a/tilework.ui/Components/Dialogs/RuleDialog.razor
+++ b/tilework.ui/Components/Dialogs/RuleDialog.razor
@@ -8,8 +8,8 @@
 <MudDialog>
     <TitleContent>
         <MudText Typo="Typo.h6">
-            <MudIcon Icon="@Icons.Material.Filled.Add" Class="mr-3 mb-n1" />
-            Add rule
+            <MudIcon Icon="@Icon" Class="mr-3 mb-n1" />
+            @Title
         </MudText>
     </TitleContent>
     <DialogContent>
@@ -37,7 +37,7 @@
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
-        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit">Add</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit">@ButtonText</MudButton>
     </DialogActions>
 </MudDialog>
 
@@ -46,6 +46,9 @@
 
     [Parameter] public RuleDTO Rule { get; set; } = new();
     [Parameter] public List<TargetGroupDTO> TargetGroups { get; set; } = new();
+    [Parameter] public string Title { get; set; } = "Add rule";
+    [Parameter] public string ButtonText { get; set; } = "Add";
+    [Parameter] public string Icon { get; set; } = Icons.Material.Filled.Add;
 
     private MudForm form;
 
@@ -56,6 +59,11 @@
         if (Rule.Conditions == null || !Rule.Conditions.Any())
         {
             Rule.Conditions = new List<Condition> { new Condition() };
+        }
+
+        if (Rule.TargetGroup != Guid.Empty)
+        {
+            SelectedTargetGroup = Rule.TargetGroup;
         }
 
         await base.OnInitializedAsync();

--- a/tilework.ui/Components/Pages/LoadBalancing/LoadBalancerDetail.razor
+++ b/tilework.ui/Components/Pages/LoadBalancing/LoadBalancerDetail.razor
@@ -76,7 +76,7 @@
                         <PropertyColumn Property="t => _loadBalancerService.GetTargetGroup(t.TargetGroup).Result.Name" Title="Target group" />
                         <TemplateColumn CellClass="d-flex justify-end">
                             <CellTemplate>
-                                <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@context.Actions.StartEditingItemAsync" />
+                                <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@(() => EditRule(context.Item))" />
                                 <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Delete" Color="Color.Error" OnClick="@(() => ConfirmDeleteRule(context.Item))" />
                             </CellTemplate>
                         </TemplateColumn>
@@ -186,6 +186,47 @@
             else
             {
                 _snackbar.Add("Can only add rules to application load balancers", Severity.Error);
+            }
+        }
+    }
+
+    private async Task EditRule(RuleDTO rule)
+    {
+        var ruleEdit = new RuleDTO
+        {
+            Id = rule.Id,
+            Priority = rule.Priority,
+            LoadBalancer = rule.LoadBalancer,
+            TargetGroup = rule.TargetGroup,
+            Conditions = rule.Conditions.Select(c => new Condition
+            {
+                Type = c.Type,
+                Values = c.Values.ToList()
+            }).ToList()
+        };
+
+        var parameters = new DialogParameters<RuleDialog>();
+        parameters.Add(x => x.Rule, ruleEdit);
+        parameters.Add(x => x.TargetGroups, await GetAlbTargetGroups());
+        parameters.Add(x => x.Title, "Edit rule");
+        parameters.Add(x => x.ButtonText, "Save");
+        parameters.Add(x => x.Icon, Icons.Material.Filled.Edit);
+
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+
+        var dialog = _dialogService.Show<RuleDialog>("Edit rule", parameters, options);
+        var result = await dialog.Result;
+        if (!result.Canceled)
+        {
+            if (_item is ApplicationLoadBalancerDTO appBalancer)
+            {
+                await _loadBalancerService.UpdateRule(appBalancer, ruleEdit);
+                await GetRules();
+                await _loadBalancerService.ApplyConfiguration();
+            }
+            else
+            {
+                _snackbar.Add("Can only edit rules on application load balancers", Severity.Error);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Allow editing existing load balancer rules through a pre-filled modal
- Extend rule dialog to accept custom titles and button labels
- Add backend support to update load balancer rules

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a1740378f483258d3d7d7d68f0fc05