### PR TITLE
Fix load balancer certificate retrieval

### DIFF
--- a/tilework.core/Persistence/Entities/LoadBalancing/BaseLoadBalancer.cs
+++ b/tilework.core/Persistence/Entities/LoadBalancing/BaseLoadBalancer.cs
@@ -18,5 +18,5 @@ public abstract class BaseLoadBalancer
 
     public bool Enabled { get; set; }
 
-    public List<Certificate> Certificates { get; set; } = new();
+    public virtual List<Certificate> Certificates { get; set; } = new();
 }


### PR DESCRIPTION
## Summary
- make `BaseLoadBalancer.Certificates` virtual so EF Core lazy loading proxies can load assigned certificates

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a421cee8a483259a06412a56cceec8